### PR TITLE
Upgrade Scala to 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.5, 3.0.0-RC2, 3.0.0-RC3]
+        scala: [2.12.13, 2.13.5, 3.0.0]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -131,22 +131,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.0.0-RC2)
+      - name: Download target directories (3.0.0)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.0.0-RC2-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.0.0-${{ matrix.java }}
 
-      - name: Inflate target directories (3.0.0-RC2)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.0.0-RC3)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-3.0.0-RC3-${{ matrix.java }}
-
-      - name: Inflate target directories (3.0.0-RC3)
+      - name: Inflate target directories (3.0.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,5 +8,4 @@ pull_request_rules:
   - body~=labels:.*semver-patch.*
   - status-success=Build and Test (ubuntu-latest, 2.12.13, adopt@1.8)
   - status-success=Build and Test (ubuntu-latest, 2.13.5, adopt@1.8)
-  - status-success=Build and Test (ubuntu-latest, 3.0.0-RC2, adopt@1.8)
-  - status-success=Build and Test (ubuntu-latest, 3.0.0-RC3, adopt@1.8)
+  - status-success=Build and Test (ubuntu-latest, 3.0.0, adopt@1.8)

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 import sbt.ForkOptions
 import sbt.Tests._
 
-val catsV = "2.6.0"
+val catsV = "2.6.1"
 val scalacheckV = "1.15.4"
-val disciplineMunitV = "1.0.8"
+val disciplineMunitV = "1.0.9"
 
 enablePlugins(SonatypeCiReleasePlugin)
 
@@ -42,7 +42,7 @@ lazy val testing = crossProject(JSPlatform, JVMPlatform)
     )
   )
   .jsSettings(
-    libraryDependencies += "io.github.cquiroz" %%% "scala-java-locales" % "1.1.3"
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-locales" % "1.2.0"
   )
   .dependsOn(core)
 
@@ -135,7 +135,7 @@ inThisBuild(List(
   publishFullName := "Ross A. Baker",
   baseVersion := "1.1",
 
-  crossScalaVersions := Seq("2.12.13", Scala213, "3.0.0-RC2", "3.0.0-RC3"),
+  crossScalaVersions := Seq("2.12.13", Scala213, "3.0.0"),
   scalaVersion := crossScalaVersions.value.filter(_.startsWith("2.")).last,
   versionIntroduced := Map(
     "3.0.0-RC1" -> "1.0.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,6 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+
+// Temporary workaround
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
Upgrade Scala to 3.0.0.

Something is pulling in an old version of `sbt-dotty`, which makes resolving dependencies fail.

I have not been able to figure out what pulls in the plugin. I can see it listed when I run `plugins` in `sbt` though.

As a temporary workaround I have re-added the newest version of `sbt-dotty`.

