### PR TITLE
Add deprecated value field for backward source compatibility with http4s CaseInsensitiveString

### DIFF
--- a/core/src/main/scala/org/typelevel/ci/CIString.scala
+++ b/core/src/main/scala/org/typelevel/ci/CIString.scala
@@ -70,6 +70,9 @@ final class CIString private (override val toString: String)
   def trim: CIString = transform(_.trim)
 
   def length: Int = toString.length
+
+  @deprecated("Use toString", "0.1.0")
+  def value: String = toString
 }
 
 @suppressUnusedImportWarningForCompat


### PR DESCRIPTION
Related to https://github.com/http4s/http4s/pull/5344